### PR TITLE
byteorder no_std

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -14,7 +14,7 @@ proc-macro = true
 [dependencies]
 quote = "1.0"
 proc-macro2 = "1.0"
-byteorder = "~1.3"
+byteorder = {version = "~1.3", default-features=false }
 usbd-hid-descriptors = { path = "../descriptors", version = ">=0.1.1" }
 
 [dependencies.syn]


### PR DESCRIPTION
https://github.com/rust-lang/cargo/issues/5730 strikes again