### PR TITLE
Allow Button Bitmaps to Have Array Container

### DIFF
--- a/macros/src/item.rs
+++ b/macros/src/item.rs
@@ -24,57 +24,85 @@ pub struct ReportUnaryField {
 
 /// analyze_field constructs a main item from an item spec & field.
 pub fn analyze_field(field: Field, ft: Type, item: &ItemSpec) -> Result<ReportUnaryField> {
-    if let Type::Path(p) = ft {
+
+    let mut size: usize = 0;
+    let p = match ft {
+        Type::Array(a) => {
+            if let Expr::Lit(ExprLit { lit, .. }) = a.len {
+                if let Lit::Int(lit) = lit {
+                    if let Ok(num) = lit.base10_parse::<usize>() {
+                        size = num;
+                    }
+                }
+            }
+            if size == 0 {
+                return Err(
+                    parse::Error::new(field.ident.unwrap().span(), "`#[gen_hid_descriptor]` array has invalid length")
+                );
+            }
+            if let Type::Path(p) = *a.elem {
+                Some(p)
+            } else {
+                None
+            }
+        }
+        Type::Path(p) => {
+            size = 1;
+            Some(p)
+        }
+        _ => {
+            None
+        }
+    };
+
+    if let Some(p) = p {
         if p.path.segments.len() != 1 {
             return Err(
-                parse::Error::new(field.ident.unwrap().span(),"`#[gen_hid_descriptor]` internal error when unwrapping type")
+                parse::Error::new(field.ident.unwrap().span(), "`#[gen_hid_descriptor]` internal error when unwrapping type")
             );
         }
         let type_ident = p.path.segments[0].ident.clone();
-        let mut output = match type_ident.to_string().as_str() {
-            "u8" => unsigned_unary_item(field.ident.clone().unwrap(), item.kind, 8),
-            "u16" => unsigned_unary_item(field.ident.clone().unwrap(), item.kind, 16),
-            "u32" => unsigned_unary_item(field.ident.clone().unwrap(), item.kind, 32),
-            "i8" => signed_unary_item(field.ident.clone().unwrap(), item.kind, 8),
-            "i16" => signed_unary_item(field.ident.clone().unwrap(), item.kind, 16),
-            "i32" => signed_unary_item(field.ident.clone().unwrap(), item.kind, 32),
-            _ => return Err(
-                    parse::Error::new(type_ident.span(),"`#[gen_hid_descriptor]` type not supported")
-            ),
+
+        let type_str = type_ident.to_string();
+        let (sign, size_str) = type_str.as_str().split_at(1);
+        let container_size = size_str.parse();
+        let type_constructor: Option<fn(Ident, MainItemKind, usize) -> ReportUnaryField> = match sign {
+            "u" => Some(unsigned_unary_item),
+            "i" => Some(signed_unary_item),
+            &_ => None
         };
-        if let Some(want_bits) = item.want_bits {
+
+        if container_size.is_err() || type_constructor.is_none() {
+            return Err(
+                parse::Error::new(type_ident.span(), "`#[gen_hid_descriptor]` type not supported")
+            )
+        }
+        let container_size = container_size.unwrap();
+        // FIXME: panic on logical max/max calc on large types.
+        let mut output = type_constructor.unwrap()(field.ident.clone().unwrap(), item.kind, container_size);
+
+        if let Some(want_bits) = item.want_bits {  // bitpack
             output.descriptor_item.logical_minimum = 0;
             output.descriptor_item.logical_maximum = 1;
             output.descriptor_item.report_count = want_bits;
             output.descriptor_item.report_size = 1;
-            let remaining_bits = output.bit_width as u16 - want_bits;
+            let width = output.bit_width * size;
+            if width < want_bits as usize {
+                return Err(
+                    parse::Error::new(field.ident.unwrap().span(), "`#[gen_hid_descriptor]` bit_width < want_bits")
+                )
+            }
+            let remaining_bits = width as u16 - want_bits;
             if remaining_bits > 0 {
                 output.descriptor_item.padding_bits = Some(remaining_bits);
             }
-        };
+        } else { // array of reports
+            // output.descriptor_item.logical_minimum = 0;
+            // output.descriptor_item.logical_maximum = 1;
+        }
+
+        output.descriptor_item.report_count *= size as u16;
         Ok(output)
-    } else if let Type::Array(a) = ft {
-        let mut size: usize = 0;
-        if let Expr::Lit(ExprLit{lit, ..}) = a.len {
-            if let Lit::Int(lit) = lit {
-                if let Ok(num) = lit.base10_parse::<usize>() {
-                    size = num;
-                }
-            }
-        }
-        if size == 0 {
-            return Err(
-                parse::Error::new(field.ident.unwrap().span(),"`#[gen_hid_descriptor]` array has invalid length")
-            );
-        }
-        // Recurse for the native data type, then mutate it to account for the repetition.
-        match analyze_field(field, *a.elem, item) {
-            Err(e) => Err(e),
-            Ok(mut f) => {
-                    f.descriptor_item.report_count = f.descriptor_item.report_count * size as u16;
-                    Ok(f)
-            },
-        }
     } else {
         Err(
             parse::Error::new(field.ident.unwrap().span(),"`#[gen_hid_descriptor]` cannot handle field type")
@@ -86,9 +114,9 @@ fn signed_unary_item(id: Ident, kind: MainItemKind, bit_width: usize) -> ReportU
     let bound = 2u32.pow((bit_width-1) as u32) as isize - 1;
     ReportUnaryField{
         ident: id,
-        bit_width: bit_width,
+        bit_width,
         descriptor_item: MainItem{
-            kind: kind,
+            kind,
             logical_minimum: -bound,
             logical_maximum: bound,
             report_count: 1,
@@ -101,9 +129,9 @@ fn signed_unary_item(id: Ident, kind: MainItemKind, bit_width: usize) -> ReportU
 fn unsigned_unary_item(id: Ident, kind: MainItemKind, bit_width: usize) -> ReportUnaryField {
     ReportUnaryField{
         ident: id,
-        bit_width: bit_width,
+        bit_width,
         descriptor_item: MainItem{
-            kind: kind,
+            kind,
             logical_minimum: 0,
             logical_maximum: 2u32.pow(bit_width as u32) as isize - 1,
             report_count: 1,

--- a/macros/src/item.rs
+++ b/macros/src/item.rs
@@ -58,7 +58,7 @@ pub fn analyze_field(field: Field, ft: Type, item: &ItemSpec) -> Result<ReportUn
         let width = output.bit_width * size;
         if width < want_bits as usize {
             return Err(
-                parse::Error::new(field.ident.unwrap().span(), "`#[gen_hid_descriptor]` not enough space")
+                parse::Error::new(field.ident.unwrap().span(), format!("`#[gen_hid_descriptor]` not enough space, missing {} bit(s)", want_bits as usize - width))
             )
         }
         let remaining_bits = width as u16 - want_bits;

--- a/macros/src/item.rs
+++ b/macros/src/item.rs
@@ -48,6 +48,13 @@ pub fn analyze_field(field: Field, ft: Type, item: &ItemSpec) -> Result<ReportUn
         )
     }
     let bit_width = bit_width.unwrap();
+
+    if bit_width >= 64 {
+        return Err(
+            parse::Error::new(type_ident.span(), "`#[gen_hid_descriptor]` integer larger than 64 is not supported in ssmarshal")
+        )
+    }
+
     let mut output = unary_item(field.ident.clone().unwrap(), item.kind, bit_width);
 
     if let Some(want_bits) = item.want_bits {  // bitpack

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -526,7 +526,6 @@ impl DescCompilation {
             let f = spec.get(name.clone()).unwrap();
             match f {
                 Spec::MainItem(i) => {
-                    // println!("field: {:?}", i);
                     let d = field_decl(fields, name);
                     match analyze_field(d.clone(), d.ty, i) {
                         Ok(item) => {

--- a/macros/src/packer.rs
+++ b/macros/src/packer.rs
@@ -47,7 +47,12 @@ pub fn gen_serializer(fields: Vec<ReportUnaryField>, typ: MainItemKind) -> Resul
 
         let rc = match field.descriptor_item.report_size {
             1 => {
-                elems.push(make_unary_serialize_invocation(field.bit_width, field.ident.clone(), signed));
+                if field.descriptor_item.report_count == 1 {
+                    elems.push(make_unary_serialize_invocation(field.bit_width, field.ident.clone(), signed));
+                } else {
+                    let ident = field.ident.clone();
+                    elems.push(quote!({ s.serialize_element(&self.#ident)?; }));
+                }
                 Ok(())
             },
             8 => { // u8 / i8

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,16 +173,22 @@ mod tests {
     // 0x81, 0x02,        // Input (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
     // 0x95, 0x07,        // Report Count (7)
     // 0x81, 0x03,        // Input (Const,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    // 0x95, 0x14,        // Report Count (20)
+    // 0x81, 0x02,        // Input (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    // 0x95, 0x04,        // Report Count (4)
+    // 0x81, 0x03,        // Input (Const,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
     #[gen_hid_descriptor(
         (report_id = 0x01,) = {
             #[packed_bits 3] f1=input;
             #[packed_bits 9] f2=input;
+            #[packed_bits 20] f3=input;
         }
     )]
     #[allow(dead_code)]
     struct CustomPackedBits {
         f1: u8,
         f2: u16,
+        f3: [u8; 3],
     }
 
     #[test]
@@ -190,6 +196,7 @@ mod tests {
         let expected = &[
             133u8, 1u8, 21u8, 0u8, 37u8, 1u8, 117u8, 1u8, 149u8, 3u8, 129u8, 2u8,
             149u8, 5u8, 129u8, 3u8, 149u8, 9u8, 129u8, 2u8, 149u8, 7u8, 129u8, 3u8,
+            149u8, 20u8, 129u8, 2u8, 149u8, 4u8, 129u8, 3u8,
         ];
         assert_eq!(CustomPackedBits::desc(), expected);
     }


### PR DESCRIPTION
On an item with 
```
Report Count (1) 
Report size (100)
```
The bits do not fit in a single primitive type, this change allows array storage in such instance.
It also adds error reporting when the given container is not large enough.
