### PR TITLE
Add error message when RHS is unexpected

### DIFF
--- a/macros/src/spec.rs
+++ b/macros/src/spec.rs
@@ -9,6 +9,7 @@ use syn::{Block, ExprBlock, ExprLit, ExprTuple, Lit, Stmt};
 use std::collections::HashMap;
 use std::string::String;
 use usbd_hid_descriptors::*;
+use syn::spanned::Spanned;
 
 // Spec describes an item within a HID report.
 #[derive(Debug, Clone)]
@@ -302,6 +303,11 @@ fn parse_group_spec(input: ParseStream, field: Expr) -> Result<GroupSpec> {
                     return Err(parse::Error::new(input.span(), "`#[gen_hid_descriptor]` group spec body can only contain semicolon-separated fields"));
                 }
             }
+        } else {
+            return Err(parse::Error::new(
+                right.span(),
+                "`#[gen_hid_descriptor]` group spec rhs must be a block (did you miss a `,`)",
+            ))
         };
     };
     Ok(out)


### PR DESCRIPTION
Will produce an error like this
```
error: `#[gen_hid_descriptor]` group spec rhs must be a block (did you miss a `,`)
   --> src/descriptor.rs:123:27
    |
123 |       (report_id = 0x01,) = {
    |  ___________________________^
124 | |         #[packed_bits 3] f1=input;
125 | |         #[packed_bits 9] f2=input
126 | |     }
127 | |     (report_id = 0x02,) = {
128 | |         #[packed_bits 20] f3=input
129 | |     }
    | |_____^

```