### PR TITLE
Adding SystemControlReport example

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -521,6 +521,16 @@ impl DescCompilation {
                 false,
             );
         }
+        if let Some(logical_minimum) = spec.logical_min {
+            self.emit_item(
+                elems,
+                ItemType::Main.into(),
+                GlobalItemKind::LogicalMin.into(),
+                logical_minimum as isize,
+                false,
+                false,
+            );
+        }
 
         for name in spec.clone() {
             let f = spec.get(name.clone()).unwrap();

--- a/macros/src/spec.rs
+++ b/macros/src/spec.rs
@@ -45,6 +45,7 @@ pub struct GroupSpec {
     pub report_id: Option<u32>,
     pub usage_page: Option<u32>,
     pub collection: Option<u32>,
+    pub logical_min: Option<u32>,
 
     // Local items
     pub usage: Vec<u32>,
@@ -119,6 +120,10 @@ impl GroupSpec {
                 self.usage_max = Some(val);
                 Ok(())
             }
+            "logical_min" => {
+                self.logical_min = Some(val);
+                Ok(())
+            }
             _ => Err(parse::Error::new(
                 input.span(),
                 format!(
@@ -180,6 +185,7 @@ pub fn try_resolve_constant(key_name: String, path: String) -> Option<u32> {
         ("usage", "Y") | ("usage_min", "Y") | ("usage_max", "Y") => Some(0x31),
         ("usage", "Z") | ("usage_min", "Z") | ("usage_max", "Z") => Some(0x32),
         ("usage", "WHEEL") => Some(0x38),
+        ("usage", "SYSTEM_CONTROL") => Some(0x80),
 
         // LED usage_page usage ID's.
         ("usage", "NUM_LOCK") => Some(0x01),

--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -117,3 +117,78 @@ impl From<MediaKey> for u16 {
         mk as u16
     }
 }
+
+/// SystemControlReport describes a report and descriptor that can be used to
+/// send system control commands to the host.
+///
+/// This is commonly used to enter sleep mode, power down, hibernate, etc.
+///
+/// Reference: https://usb.org/sites/default/files/hut1_2.pdf
+///
+/// NOTE: For Windows compatibility usage_min should start at 0x81
+/// NOTE: For macOS scrollbar compatibility, logical minimum should start from 1
+///       (scrollbars disappear if logical_min is set to 0)
+#[gen_hid_descriptor(
+    (collection = APPLICATION, usage_page = GENERIC_DESKTOP, usage = SYSTEM_CONTROL) = {
+        (usage_min = 0x81, usage_max = 0xB7, logical_min = 1) = {
+            #[item_settings data,array,absolute,not_null] usage_id=input;
+        };
+    }
+)]
+#[allow(dead_code)]
+pub struct SystemControlReport {
+    pub usage_id: u8,
+}
+
+/// System control usage ids to use with SystemControlReport
+#[non_exhaustive]
+#[repr(u8)]
+#[derive(Debug)]
+pub enum SystemControlKey {
+    PowerDown = 0x81,
+    Sleep = 0x82,
+    WakeUp = 0x83,
+    ContextMenu = 0x84,
+    MainMenu = 0x85,
+    AppMenu = 0x86,
+    MenuHelp = 0x87,
+    MenuExit = 0x88,
+    MenuSelect = 0x89,
+    MenuRight = 0x8A,
+    MenuLeft = 0x8B,
+    MenuUp = 0x8C,
+    MenuDown = 0x8D,
+    ColdRestart = 0x8E,
+    WarmRestart = 0x8F,
+    DpadUp = 0x90,
+    DpadDown = 0x91,
+    DpadRight = 0x92,
+    DpadLeft = 0x93,
+    SystemFunctionShift = 0x97,
+    SystemFunctionShiftLock = 0x98,
+    SystemDismissNotification = 0x9A,
+    SystemDoNotDisturb = 0x9B,
+    Dock = 0xA0,
+    Undock = 0xA1,
+    Setup = 0xA2,
+    Break = 0xA3,
+    DebuggerBreak = 0xA4,
+    ApplicationBreak = 0xA5,
+    ApplicationDebuggerBreak = 0xA6,
+    SpeakerMute = 0xA7,
+    Hibernate = 0xA8,
+    DisplayInvert = 0xB0,
+    DisplayInternal = 0xB1,
+    DisplayExternal = 0xB2,
+    DisplayBoth = 0xB3,
+    DisplayDual = 0xB4,
+    DisplayToggleInternalExternal = 0xB5,
+    DisplaySwapPrimarySecondary = 0xB6,
+    DisplayLcdAutoscale = 0xB7,
+}
+
+impl From<SystemControlKey> for u8 {
+    fn from(sck: SystemControlKey) -> u8 {
+        sck as u8
+    }
+}


### PR DESCRIPTION
- Added support for custom logical_min setting
  * Needed for Windows HID parser quirk