### PR TITLE
Adding support for get/set_protocol

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -151,7 +151,7 @@ use packer::{gen_serializer, uses_report_ids};
 ///
 /// ## `collection-spec`:
 ///
-/// ```
+/// ```text
 ///     (parameter = <constant or 0xxxx>, ...) = {
 ///         <collection-spec> OR <item-spec>;
 ///         ...

--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -89,7 +89,7 @@ pub struct KeyboardReport {
 /// This is commonly used for sending media player for keyboards with media player
 /// keys, but can be used for all sorts of Consumer Page functionality.
 ///
-/// Reference: https://usb.org/sites/default/files/hut1_2.pdf
+/// Reference: <https://usb.org/sites/default/files/hut1_2.pdf>
 ///
 #[gen_hid_descriptor(
     (collection = APPLICATION, usage_page = CONSUMER, usage = CONSUMER_CONTROL) = {
@@ -133,7 +133,7 @@ impl From<MediaKey> for u16 {
 ///
 /// This is commonly used to enter sleep mode, power down, hibernate, etc.
 ///
-/// Reference: https://usb.org/sites/default/files/hut1_2.pdf
+/// Reference: <https://usb.org/sites/default/files/hut1_2.pdf>
 ///
 /// NOTE: For Windows compatibility usage_min should start at 0x81
 /// NOTE: For macOS scrollbar compatibility, logical minimum should start from 1

--- a/src/hid_class.rs
+++ b/src/hid_class.rs
@@ -14,31 +14,31 @@ const HID_DESC_DESCTYPE_HID_REPORT: u8 = 0x22;
 const HID_DESC_SPEC_1_10: [u8; 2] = [0x10, 0x01];
 
 /// Requests the set idle rate from the device
-/// See (7.2.3): https://www.usb.org/sites/default/files/hid1_11.pdf
+/// See (7.2.3): <https://www.usb.org/sites/default/files/hid1_11.pdf>
 const HID_REQ_GET_IDLE: u8 = 0x02;
 
 /// Requests device to not send a particular report until a new event occurs
 /// or the specified amount of time passes.
-/// See (7.2.4): https://www.usb.org/sites/default/files/hid1_11.pdf
+/// See (7.2.4): <https://www.usb.org/sites/default/files/hid1_11.pdf>
 const HID_REQ_SET_IDLE: u8 = 0x0a;
 
 /// Requests the active protocol on the device (boot or report)
-/// See (7.2.5): https://www.usb.org/sites/default/files/hid1_11.pdf
+/// See (7.2.5): <https://www.usb.org/sites/default/files/hid1_11.pdf>
 const HID_REQ_GET_PROTOCOL: u8 = 0x03;
 
 /// Switches the device between boot and report protocols. Devices must default
 /// to report protocol, it is the reponsibility of the host to set the device
 /// to boot protocol (NOTE: Sadly many OSs, BIOSs and bootloaders do not adhere
 /// to the USB spec here).
-/// See (7.2.6): https://www.usb.org/sites/default/files/hid1_11.pdf
+/// See (7.2.6): <https://www.usb.org/sites/default/files/hid1_11.pdf>
 const HID_REQ_SET_PROTOCOL: u8 = 0x0b;
 
 /// Allows a host to receive a report via the Control pipe
-/// See (7.2.1): https://www.usb.org/sites/default/files/hid1_11.pdf
+/// See (7.2.1): <https://www.usb.org/sites/default/files/hid1_11.pdf>
 const HID_REQ_GET_REPORT: u8 = 0x01;
 
 /// Allows the host to send a report to the device via the Control pipe
-/// See (7.2.2): https://www.usb.org/sites/default/files/hid1_11.pdf
+/// See (7.2.2): <https://www.usb.org/sites/default/files/hid1_11.pdf>
 const HID_REQ_SET_REPORT: u8 = 0x09;
 
 /// See CONTROL_BUF_LEN from usb-device.git src/control_pipe.rs
@@ -77,7 +77,7 @@ struct Report {
 }
 
 /// List of official USB HID country codes
-/// See (6.2.1): https://www.usb.org/sites/default/files/hid1_11.pdf
+/// See (6.2.1): <https://www.usb.org/sites/default/files/hid1_11.pdf>
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(u8)]
 pub enum HidCountryCode {
@@ -120,9 +120,9 @@ pub enum HidCountryCode {
 }
 
 /// Used to enable Boot mode descriptors for Mouse and Keyboard devices.
-/// See (4.2): https://www.usb.org/sites/default/files/hid1_11.pdf
+/// See (4.2): <https://www.usb.org/sites/default/files/hid1_11.pdf>
 /// Boot mode descriptors are fixed and must follow a strict format.
-/// See (Appendix F): https://www.usb.org/sites/default/files/hid1_11.pdf
+/// See (Appendix F): <https://www.usb.org/sites/default/files/hid1_11.pdf>
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(u8)]
 pub enum HidSubClass {
@@ -132,7 +132,7 @@ pub enum HidSubClass {
 
 /// Defines fixed packet format
 /// Only used if HidSubClass::Boot(1) is set
-/// See (4.3): https://www.usb.org/sites/default/files/hid1_11.pdf
+/// See (4.3): <https://www.usb.org/sites/default/files/hid1_11.pdf>
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(u8)]
 pub enum HidProtocol {
@@ -142,7 +142,7 @@ pub enum HidProtocol {
 }
 
 /// Get/Set Protocol mapping
-/// See (7.2.5 and 7.2.6): https://www.usb.org/sites/default/files/hid1_11.pdf
+/// See (7.2.5 and 7.2.6): <https://www.usb.org/sites/default/files/hid1_11.pdf>
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(u8)]
 pub enum HidProtocolMode {
@@ -208,7 +208,7 @@ pub struct HIDClass<'a, B: UsbBus> {
     in_ep: Option<EndpointIn<'a, B>>,
     report_descriptor: &'static [u8],
     /// Control endpoint alternative OUT buffer (always used for setting feature reports)
-    /// See: https://www.usb.org/sites/default/files/documents/hid1_11.pdf 7.2.1 and 7.2.2
+    /// See: <https://www.usb.org/sites/default/files/documents/hid1_11.pdf> 7.2.1 and 7.2.2
     set_report_buf: Option<Report>,
     /// Used only by Keyboard and Mouse to define BIOS (Boot) mode vs Normal (Report) mode.
     /// This is used to switch between 6KRO (boot) and NKRO (report) endpoints.
@@ -218,7 +218,7 @@ pub struct HIDClass<'a, B: UsbBus> {
     ///
     /// If a device does not request boot mode, this is a host bug. For convenience this API allows
     /// manually setting the protocol.
-    /// See https://www.usb.org/sites/default/files/hid1_11.pdf Section 7.2.6
+    /// See <https://www.usb.org/sites/default/files/hid1_11.pdf> Section 7.2.6
     protocol: Option<HidProtocolMode>,
     settings: HidClassSettings,
 }
@@ -471,7 +471,7 @@ impl<B: UsbBus> HIDClass<'_, B> {
 
     /// Retrieves the currently set device protocol
     /// This is equivalent to the USB HID GET_PROTOCOL request
-    /// See (7.2.5): https://www.usb.org/sites/default/files/hid1_11.pdf
+    /// See (7.2.5): <https://www.usb.org/sites/default/files/hid1_11.pdf>
     pub fn get_protocol_mode(&self) -> Result<HidProtocolMode> {
         // Protocol mode only has meaning if Keyboard or Mouse Protocol is set
         match self.settings.protocol {
@@ -491,7 +491,7 @@ impl<B: UsbBus> HIDClass<'_, B> {
     /// Forcibly sets the device protocol
     /// This is equivalent to the USB HID SET_PROTOCOL request.
     /// NOTE: If the OS does not support the new mode, the device may no longer work correctly.
-    /// See (7.2.6): https://www.usb.org/sites/default/files/hid1_11.pdf
+    /// See (7.2.6): <https://www.usb.org/sites/default/files/hid1_11.pdf>
     ///
     /// If either, ForceBoot or ForceReport are set in config, the mode argument is ignored.
     /// In addition, if ForceBoot or ForceReport are set, then any SET_PROTOCOL requests are also

--- a/src/hid_class.rs
+++ b/src/hid_class.rs
@@ -7,22 +7,42 @@ extern crate ssmarshal;
 use ssmarshal::serialize;
 
 const USB_CLASS_HID: u8 = 0x03;
-const USB_SUBCLASS_NONE: u8 = 0x00;
-const USB_PROTOCOL_NONE: u8 = 0x00;
 
 // HID
 const HID_DESC_DESCTYPE_HID: u8 = 0x21;
 const HID_DESC_DESCTYPE_HID_REPORT: u8 = 0x22;
 const HID_DESC_SPEC_1_10: [u8; 2] = [0x10, 0x01];
-const HID_DESC_COUNTRY_UNSPEC: u8 = 0x00;
 
-const HID_REQ_SET_IDLE: u8 = 0x0a;
+/// Requests the set idle rate from the device
+/// See (7.2.3): https://www.usb.org/sites/default/files/hid1_11.pdf
 const HID_REQ_GET_IDLE: u8 = 0x02;
+
+/// Requests device to not send a particular report until a new event occurs
+/// or the specified amount of time passes.
+/// See (7.2.4): https://www.usb.org/sites/default/files/hid1_11.pdf
+const HID_REQ_SET_IDLE: u8 = 0x0a;
+
+/// Requests the active protocol on the device (boot or report)
+/// See (7.2.5): https://www.usb.org/sites/default/files/hid1_11.pdf
+const HID_REQ_GET_PROTOCOL: u8 = 0x03;
+
+/// Switches the device between boot and report protocols. Devices must default
+/// to report protocol, it is the reponsibility of the host to set the device
+/// to boot protocol (NOTE: Sadly many OSs, BIOSs and bootloaders do not adhere
+/// to the USB spec here).
+/// See (7.2.6): https://www.usb.org/sites/default/files/hid1_11.pdf
+const HID_REQ_SET_PROTOCOL: u8 = 0x0b;
+
+/// Allows a host to receive a report via the Control pipe
+/// See (7.2.1): https://www.usb.org/sites/default/files/hid1_11.pdf
 const HID_REQ_GET_REPORT: u8 = 0x01;
+
+/// Allows the host to send a report to the device via the Control pipe
+/// See (7.2.2): https://www.usb.org/sites/default/files/hid1_11.pdf
 const HID_REQ_SET_REPORT: u8 = 0x09;
 
-// See CONTROL_BUF_LEN from usb-device.git src/control_pipe.rs
-// Will need to revisit how this is set once usb-device has true HiSpeed USB support.
+/// See CONTROL_BUF_LEN from usb-device.git src/control_pipe.rs
+/// Will need to revisit how this is set once usb-device has true HiSpeed USB support.
 const CONTROL_BUF_LEN: usize = 128;
 
 #[derive(Copy, Clone)]
@@ -56,6 +76,126 @@ struct Report {
     buf: [u8; CONTROL_BUF_LEN],
 }
 
+/// List of official USB HID country codes
+/// See (6.2.1): https://www.usb.org/sites/default/files/hid1_11.pdf
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(u8)]
+pub enum HidCountryCode {
+    NotSupported = 0,
+    Arabic = 1,
+    Belgian = 2,
+    CanadianBilingual = 3,
+    CanadianFrench = 4,
+    CzechRepublic = 5,
+    Danish = 6,
+    Finnish = 7,
+    French = 8,
+    German = 9,
+    Greek = 10,
+    Hebrew = 11,
+    Hungary = 12,
+    InternationalISO = 13,
+    Italian = 14,
+    JapanKatakana = 15,
+    Korean = 16,
+    LatinAmerica = 17,
+    NetherlandsDutch = 18,
+    Norwegian = 19,
+    PersianFarsi = 20,
+    Poland = 21,
+    Portuguese = 22,
+    Russia = 23,
+    Slovakia = 24,
+    Spanish = 25,
+    Swedish = 26,
+    SwissFrench = 27,
+    SwissGerman = 28,
+    Switzerland = 29,
+    Taiwan = 30,
+    TurkishQ = 31,
+    UK = 32,
+    US = 33,
+    Yugoslavia = 34,
+    TurkishF = 35,
+}
+
+/// Used to enable Boot mode descriptors for Mouse and Keyboard devices.
+/// See (4.2): https://www.usb.org/sites/default/files/hid1_11.pdf
+/// Boot mode descriptors are fixed and must follow a strict format.
+/// See (Appendix F): https://www.usb.org/sites/default/files/hid1_11.pdf
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(u8)]
+pub enum HidSubClass {
+    NoSubClass = 0,
+    Boot = 1,
+}
+
+/// Defines fixed packet format
+/// Only used if HidSubClass::Boot(1) is set
+/// See (4.3): https://www.usb.org/sites/default/files/hid1_11.pdf
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(u8)]
+pub enum HidProtocol {
+    Generic = 0,
+    Keyboard = 1,
+    Mouse = 2,
+}
+
+/// Get/Set Protocol mapping
+/// See (7.2.5 and 7.2.6): https://www.usb.org/sites/default/files/hid1_11.pdf
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(u8)]
+pub enum HidProtocolMode {
+    Boot = 0,
+    Report = 1,
+}
+
+impl From<u8> for HidProtocolMode {
+    fn from(mode: u8) -> HidProtocolMode {
+        if mode == HidProtocolMode::Boot as u8 {
+            HidProtocolMode::Boot
+        } else {
+            HidProtocolMode::Report
+        }
+    }
+}
+
+/// It is often necessary to override OS behavior in order to get around OS (and application) level
+/// bugs. Forcing either Boot mode (6KRO) and Report mode (NKRO) are often necessary for NKRO
+/// compatible keyboards. Mice that support boot mode are not common and generally only useful for
+/// legacy OSs.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum ProtocolModeConfig {
+    /// Allows the host to define boot or report mode. Defaults to report mode.
+    DefaultBehavior,
+    /// Forces protocol mode to boot mode
+    ForceBoot,
+    /// Forces protocol mode to report mode
+    ForceReport,
+}
+
+/// Used to define specialized HID device settings
+/// Most commonly used to setup Boot Mode (6KRO) or Report Mode (NKRO) keyboards.
+/// Some OSs will also respect the HID locale setting of the keyboard to help choose the OS
+/// keyboard layout.
+pub struct HidClassSettings {
+    pub subclass: HidSubClass,
+    pub protocol: HidProtocol,
+    pub config: ProtocolModeConfig,
+    pub locale: HidCountryCode,
+}
+
+impl Default for HidClassSettings {
+    fn default() -> Self {
+        Self {
+            subclass: HidSubClass::NoSubClass,
+            protocol: HidProtocol::Generic,
+            config: ProtocolModeConfig::DefaultBehavior,
+            locale: HidCountryCode::NotSupported,
+        }
+    }
+}
+
 /// HIDClass provides an interface to declare, read & write HID reports.
 ///
 /// Users are expected to provide the report descriptor, as well as pack
@@ -70,6 +210,30 @@ pub struct HIDClass<'a, B: UsbBus> {
     /// Control endpoint alternative OUT buffer (always used for setting feature reports)
     /// See: https://www.usb.org/sites/default/files/documents/hid1_11.pdf 7.2.1 and 7.2.2
     set_report_buf: Option<Report>,
+    /// Used only by Keyboard and Mouse to define BIOS (Boot) mode vs Normal (Report) mode.
+    /// This is used to switch between 6KRO (boot) and NKRO (report) endpoints.
+    /// Boot mode configured endpoints may not parse the hid descriptor and expect an exact
+    /// hid packet format. By default a device should start in normal (report) mode and the host
+    /// must request the boot mode protocol if it requires it.
+    ///
+    /// If a device does not request boot mode, this is a host bug. For convenience this API allows
+    /// manually setting the protocol.
+    /// See https://www.usb.org/sites/default/files/hid1_11.pdf Section 7.2.6
+    protocol: Option<HidProtocolMode>,
+    settings: HidClassSettings,
+}
+
+fn determine_protocol_setting(settings: &HidClassSettings) -> Option<HidProtocolMode> {
+    if settings.protocol == HidProtocol::Keyboard || settings.protocol == HidProtocol::Mouse {
+        match settings.config {
+            ProtocolModeConfig::DefaultBehavior | ProtocolModeConfig::ForceReport => {
+                Some(HidProtocolMode::Report)
+            }
+            ProtocolModeConfig::ForceBoot => Some(HidProtocolMode::Boot),
+        }
+    } else {
+        None
+    }
 }
 
 impl<B: UsbBus> HIDClass<'_, B> {
@@ -83,10 +247,34 @@ impl<B: UsbBus> HIDClass<'_, B> {
     /// This allocates two endpoints (IN and OUT).
     /// See new_ep_in (IN endpoint only) and new_ep_out (OUT endpoint only) to only create a single
     /// endpoint.
+    ///
+    /// See new_with_settings() if you need to define protocol or locale settings for a IN/OUT
+    /// HID interface.
     pub fn new<'a>(
         alloc: &'a UsbBusAllocator<B>,
         report_descriptor: &'static [u8],
         poll_ms: u8,
+    ) -> HIDClass<'a, B> {
+        let settings = HidClassSettings::default();
+        HIDClass {
+            if_num: alloc.interface(),
+            out_ep: Some(alloc.interrupt(64, poll_ms)),
+            in_ep: Some(alloc.interrupt(64, poll_ms)),
+            report_descriptor,
+            set_report_buf: None,
+            protocol: determine_protocol_setting(&settings),
+            settings,
+        }
+    }
+
+    /// Same as new() but includes a settings field.
+    /// The settings field is used to define both locale and protocol settings of the HID
+    /// device (needed for HID keyboard and Mice).
+    pub fn new_with_settings<'a>(
+        alloc: &'a UsbBusAllocator<B>,
+        report_descriptor: &'static [u8],
+        poll_ms: u8,
+        settings: HidClassSettings,
     ) -> HIDClass<'a, B> {
         HIDClass {
             if_num: alloc.interface(),
@@ -94,15 +282,39 @@ impl<B: UsbBus> HIDClass<'_, B> {
             in_ep: Some(alloc.interrupt(64, poll_ms)),
             report_descriptor,
             set_report_buf: None,
+            protocol: determine_protocol_setting(&settings),
+            settings,
         }
     }
 
     /// Creates a new HIDClass with the provided UsbBus & HID report descriptor.
     /// See new() for more details.
+    /// Please use new_ep_in_with_settings() if you are creating a keyboard or mouse.
     pub fn new_ep_in<'a>(
         alloc: &'a UsbBusAllocator<B>,
         report_descriptor: &'static [u8],
         poll_ms: u8,
+    ) -> HIDClass<'a, B> {
+        let settings = HidClassSettings::default();
+        HIDClass {
+            if_num: alloc.interface(),
+            out_ep: None,
+            in_ep: Some(alloc.interrupt(64, poll_ms)),
+            report_descriptor,
+            set_report_buf: None,
+            protocol: determine_protocol_setting(&settings),
+            settings,
+        }
+    }
+
+    /// Same as new_ep_in() but includes a settings field.
+    /// The settings field is used to define both locale and protocol settings of the HID
+    /// device (needed for HID keyboard and Mice).
+    pub fn new_ep_in_with_settings<'a>(
+        alloc: &'a UsbBusAllocator<B>,
+        report_descriptor: &'static [u8],
+        poll_ms: u8,
+        settings: HidClassSettings,
     ) -> HIDClass<'a, B> {
         HIDClass {
             if_num: alloc.interface(),
@@ -110,15 +322,39 @@ impl<B: UsbBus> HIDClass<'_, B> {
             in_ep: Some(alloc.interrupt(64, poll_ms)),
             report_descriptor,
             set_report_buf: None,
+            protocol: determine_protocol_setting(&settings),
+            settings,
         }
     }
 
     /// Creates a new HIDClass with the provided UsbBus & HID report descriptor.
     /// See new() for more details.
+    /// Please use new_ep_out_with_settings if you need the settings field.
     pub fn new_ep_out<'a>(
         alloc: &'a UsbBusAllocator<B>,
         report_descriptor: &'static [u8],
         poll_ms: u8,
+    ) -> HIDClass<'a, B> {
+        let settings = HidClassSettings::default();
+        HIDClass {
+            if_num: alloc.interface(),
+            out_ep: Some(alloc.interrupt(64, poll_ms)),
+            in_ep: None,
+            report_descriptor,
+            set_report_buf: None,
+            protocol: determine_protocol_setting(&settings),
+            settings,
+        }
+    }
+
+    /// Same as new_ep_out() but includes a settings field.
+    /// This should be uncommon (non-standard), but is included for completeness as there
+    /// may be cases where setting the locale is useful.
+    pub fn new_ep_out_with_settings<'a>(
+        alloc: &'a UsbBusAllocator<B>,
+        report_descriptor: &'static [u8],
+        poll_ms: u8,
+        settings: HidClassSettings,
     ) -> HIDClass<'a, B> {
         HIDClass {
             if_num: alloc.interface(),
@@ -126,6 +362,8 @@ impl<B: UsbBus> HIDClass<'_, B> {
             in_ep: None,
             report_descriptor,
             set_report_buf: None,
+            protocol: determine_protocol_setting(&settings),
+            settings,
         }
     }
 
@@ -133,6 +371,22 @@ impl<B: UsbBus> HIDClass<'_, B> {
     /// A BufferOverflow error is returned if the serialized report is greater than
     /// 64 bytes in size.
     pub fn push_input<IR: AsInputReport>(&self, r: &IR) -> Result<usize> {
+        // Do not push data if protocol settings do not match (only for keyboard and mouse)
+        match self.settings.protocol {
+            HidProtocol::Keyboard | HidProtocol::Mouse => {
+                if let Some(protocol) = self.protocol {
+                    if (protocol == HidProtocolMode::Report
+                        && self.settings.subclass != HidSubClass::NoSubClass)
+                        || (protocol == HidProtocolMode::Boot
+                            && self.settings.subclass != HidSubClass::Boot)
+                    {
+                        return Err(UsbError::InvalidState);
+                    }
+                }
+            }
+            _ => {}
+        }
+
         if let Some(ep) = &self.in_ep {
             let mut buff: [u8; 64] = [0; 64];
             let size = match serialize(&mut buff, r) {
@@ -150,6 +404,22 @@ impl<B: UsbBus> HIDClass<'_, B> {
     /// were used in the descriptor, the report ID corresponding to this report
     /// must be be present before the contents of the report.
     pub fn push_raw_input(&self, data: &[u8]) -> Result<usize> {
+        // Do not push data if protocol settings do not match (only for keyboard and mouse)
+        match self.settings.protocol {
+            HidProtocol::Keyboard | HidProtocol::Mouse => {
+                if let Some(protocol) = self.protocol {
+                    if (protocol == HidProtocolMode::Report
+                        && self.settings.subclass != HidSubClass::NoSubClass)
+                        || (protocol == HidProtocolMode::Boot
+                            && self.settings.subclass != HidSubClass::Boot)
+                    {
+                        return Err(UsbError::InvalidState);
+                    }
+                }
+            }
+            _ => {}
+        }
+
         if let Some(ep) = &self.in_ep {
             ep.write(data)
         } else {
@@ -198,6 +468,60 @@ impl<B: UsbBus> HIDClass<'_, B> {
         self.set_report_buf = None;
         Ok(info)
     }
+
+    /// Retrieves the currently set device protocol
+    /// This is equivalent to the USB HID GET_PROTOCOL request
+    /// See (7.2.5): https://www.usb.org/sites/default/files/hid1_11.pdf
+    pub fn get_protocol_mode(&self) -> Result<HidProtocolMode> {
+        // Protocol mode only has meaning if Keyboard or Mouse Protocol is set
+        match self.settings.protocol {
+            HidProtocol::Keyboard | HidProtocol::Mouse => {}
+            _ => {
+                return Err(UsbError::Unsupported);
+            }
+        }
+
+        if let Some(protocol) = self.protocol {
+            Ok(protocol)
+        } else {
+            Err(UsbError::InvalidState)
+        }
+    }
+
+    /// Forcibly sets the device protocol
+    /// This is equivalent to the USB HID SET_PROTOCOL request.
+    /// NOTE: If the OS does not support the new mode, the device may no longer work correctly.
+    /// See (7.2.6): https://www.usb.org/sites/default/files/hid1_11.pdf
+    ///
+    /// If either, ForceBoot or ForceReport are set in config, the mode argument is ignored.
+    /// In addition, if ForceBoot or ForceReport are set, then any SET_PROTOCOL requests are also
+    /// ignored.
+    pub fn set_protocol_mode(
+        &mut self,
+        mode: HidProtocolMode,
+        config: ProtocolModeConfig,
+    ) -> Result<()> {
+        // Protocol mode only has meaning if Keyboard or Mouse Protocol is set
+        match self.settings.protocol {
+            HidProtocol::Keyboard | HidProtocol::Mouse => {}
+            _ => {
+                return Err(UsbError::Unsupported);
+            }
+        }
+
+        // Update the protocol setting behavior and update the protocol mode
+        match config {
+            ProtocolModeConfig::DefaultBehavior => self.protocol = Some(mode),
+            ProtocolModeConfig::ForceBoot => {
+                self.protocol = Some(HidProtocolMode::Boot);
+            }
+            ProtocolModeConfig::ForceReport => {
+                self.protocol = Some(HidProtocolMode::Report);
+            }
+        }
+        self.settings.config = config;
+        Ok(())
+    }
 }
 
 impl<B: UsbBus> UsbClass<B> for HIDClass<'_, B> {
@@ -205,8 +529,8 @@ impl<B: UsbBus> UsbClass<B> for HIDClass<'_, B> {
         writer.interface(
             self.if_num,
             USB_CLASS_HID,
-            USB_SUBCLASS_NONE,
-            USB_PROTOCOL_NONE,
+            self.settings.subclass as u8,
+            self.settings.protocol as u8,
         )?;
 
         // HID descriptor
@@ -216,8 +540,7 @@ impl<B: UsbBus> UsbClass<B> for HIDClass<'_, B> {
                 // HID Class spec version
                 HID_DESC_SPEC_1_10[0],
                 HID_DESC_SPEC_1_10[1],
-                // Country code not supported
-                HID_DESC_COUNTRY_UNSPEC,
+                self.settings.locale as u8,
                 // Number of following descriptors
                 1,
                 // We have a HID report descriptor the host should read
@@ -261,8 +584,7 @@ impl<B: UsbBus> UsbClass<B> for HIDClass<'_, B> {
                             // HID Class spec version
                             HID_DESC_SPEC_1_10[0],
                             HID_DESC_SPEC_1_10[1],
-                            // Country code not supported
-                            HID_DESC_COUNTRY_UNSPEC,
+                            self.settings.locale as u8,
                             // Number of following descriptors
                             1,
                             // We have a HID report descriptor the host should read
@@ -303,6 +625,14 @@ impl<B: UsbBus> UsbClass<B> for HIDClass<'_, B> {
                 // Each Report ID can be configured independently.
                 xfer.reject().ok(); // Not supported for now
             }
+            (control::RequestType::Class, HID_REQ_GET_PROTOCOL) => {
+                // Only accept in supported configurations
+                if let Some(protocol) = self.protocol {
+                    xfer.accept_with(&[protocol as u8]).ok();
+                } else {
+                    xfer.reject().ok();
+                }
+            }
             _ => {}
         }
     }
@@ -321,6 +651,18 @@ impl<B: UsbBus> UsbClass<B> for HIDClass<'_, B> {
         match req.request {
             HID_REQ_SET_IDLE => {
                 xfer.accept().ok();
+            }
+            HID_REQ_SET_PROTOCOL => {
+                // Only accept in supported configurations
+                if let Some(_protocol) = self.protocol {
+                    // Only set if configured to
+                    if self.settings.config == ProtocolModeConfig::DefaultBehavior {
+                        self.protocol = Some(((req.value & 0xFF) as u8).into());
+                    }
+                    xfer.accept().ok();
+                } else {
+                    xfer.reject().ok();
+                }
             }
             HID_REQ_SET_REPORT => {
                 let report_type = ((req.value >> 8) as u8).into();


### PR DESCRIPTION
- Needed to support NKRO keyboards
- Includes additional logic to force report or boot protocol in case of
  problemmatic host drivers (typically BIOSs and bootloaders)
  * It used to be very common that BIOSs did not send set_protocol to
    boot mode when requiring the boot mode keyboard descriptor
- Includes country code support
- This changes the new() functions to include a new `settings` field
   `new(alloc, report_descriptor, poll_ms, HidClassSettings::default())` maintains the previous behavior