### PR TITLE
Adding SET_REPORT support

### DIFF
--- a/src/hid_class.rs
+++ b/src/hid_class.rs
@@ -21,15 +21,55 @@ const HID_REQ_GET_IDLE: u8 = 0x02;
 const HID_REQ_GET_REPORT: u8 = 0x01;
 const HID_REQ_SET_REPORT: u8 = 0x09;
 
+// See CONTROL_BUF_LEN from usb-device.git src/control_pipe.rs
+// Will need to revisit how this is set once usb-device has true HiSpeed USB support.
+const CONTROL_BUF_LEN: usize = 128;
+
+#[derive(Copy, Clone)]
+pub enum ReportType {
+    Input = 1,
+    Output = 2,
+    Feature = 3,
+    Reserved,
+}
+
+impl From<u8> for ReportType {
+    fn from(rt: u8) -> ReportType {
+        match rt {
+            1 => ReportType::Input,
+            2 => ReportType::Output,
+            3 => ReportType::Feature,
+            _ => ReportType::Reserved,
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+pub struct ReportInfo {
+    pub report_type: ReportType,
+    pub report_id: u8,
+    pub len: usize,
+}
+
+struct Report {
+    info: ReportInfo,
+    buf: [u8; CONTROL_BUF_LEN],
+}
+
 /// HIDClass provides an interface to declare, read & write HID reports.
 ///
 /// Users are expected to provide the report descriptor, as well as pack
 /// and unpack reports which are read or staged for transmission.
 pub struct HIDClass<'a, B: UsbBus> {
     if_num: InterfaceNumber,
+    /// Low-latency OUT buffer
     out_ep: Option<EndpointOut<'a, B>>,
+    /// Low-latency IN buffer
     in_ep: Option<EndpointIn<'a, B>>,
     report_descriptor: &'static [u8],
+    /// Control endpoint alternative OUT buffer (always used for setting feature reports)
+    /// See: https://www.usb.org/sites/default/files/documents/hid1_11.pdf 7.2.1 and 7.2.2
+    set_report_buf: Option<Report>,
 }
 
 impl<B: UsbBus> HIDClass<'_, B> {
@@ -53,6 +93,7 @@ impl<B: UsbBus> HIDClass<'_, B> {
             out_ep: Some(alloc.interrupt(64, poll_ms)),
             in_ep: Some(alloc.interrupt(64, poll_ms)),
             report_descriptor,
+            set_report_buf: None,
         }
     }
 
@@ -68,6 +109,7 @@ impl<B: UsbBus> HIDClass<'_, B> {
             out_ep: None,
             in_ep: Some(alloc.interrupt(64, poll_ms)),
             report_descriptor,
+            set_report_buf: None,
         }
     }
 
@@ -83,6 +125,7 @@ impl<B: UsbBus> HIDClass<'_, B> {
             out_ep: Some(alloc.interrupt(64, poll_ms)),
             in_ep: None,
             report_descriptor,
+            set_report_buf: None,
         }
     }
 
@@ -124,6 +167,37 @@ impl<B: UsbBus> HIDClass<'_, B> {
             Err(UsbError::InvalidEndpoint)
         }
     }
+
+    /// Tries to read an incoming SET_REPORT report as raw bytes.
+    /// Unlike OUT endpoints, report IDs are not prefixed in the buffer. Use the returned tuple
+    /// instead to determine the buffer's usage.
+    ///
+    /// The most common usage of pull_raw_report is for keyboard lock LED status if an OUT endpoint
+    /// is not defined. It is not necessary to call this function if you're not going to be using
+    /// SET_REPORT functionality.
+    pub fn pull_raw_report(&mut self, data: &mut [u8]) -> Result<ReportInfo> {
+        let info = match &self.set_report_buf {
+            Some(set_report_buf) => {
+                let info = set_report_buf.info;
+
+                // Make sure the given buffer is large enough for the stored report
+                if data.len() < info.len {
+                    return Err(UsbError::BufferOverflow);
+                }
+
+                // Copy buffer
+                data.copy_from_slice(&set_report_buf.buf);
+                info
+            }
+            None => {
+                return Err(UsbError::WouldBlock);
+            }
+        };
+
+        // Clear the report
+        self.set_report_buf = None;
+        Ok(info)
+    }
 }
 
 impl<B: UsbBus> UsbClass<B> for HIDClass<'_, B> {
@@ -155,10 +229,10 @@ impl<B: UsbBus> UsbClass<B> for HIDClass<'_, B> {
         )?;
 
         if let Some(ep) = &self.out_ep {
-            writer.endpoint(&ep)?;
+            writer.endpoint(ep)?;
         }
         if let Some(ep) = &self.in_ep {
-            writer.endpoint(&ep)?;
+            writer.endpoint(ep)?;
         }
         Ok(())
     }
@@ -203,9 +277,30 @@ impl<B: UsbBus> UsbClass<B> for HIDClass<'_, B> {
                 }
             }
             (control::RequestType::Class, HID_REQ_GET_REPORT) => {
+                // To support GET_REPORT correctly each request must be serviced immediately.
+                // This complicates the current API and may require a standing copy of each
+                // of the possible IN reports (as well as any FEATURE reports as well).
+                // For most projects, GET_REPORT won't be necessary so until a project comes along
+                // with a need for it, I think it's safe to leave unsupported.
+                // See: https://www.usb.org/sites/default/files/documents/hid1_11.pdf 7.2.1
                 xfer.reject().ok(); // Not supported for now
             }
             (control::RequestType::Class, HID_REQ_GET_IDLE) => {
+                // XXX (HaaTa): As a note for future readers
+                // GET/SET_IDLE tends to be rather buggy on the host side
+                // macOS is known to set SET_IDLE for keyboards but most other OSs do not.
+                // I haven't had much success in the past trying to enable GET/SET_IDLE for
+                // macOS (it seems to expose other bugs in the macOS hid stack).
+                // The interesting part is that SET_IDLE is not called for official Apple
+                // keyboards. So beyond getting 100% compliance from the USB compliance tools
+                // IDLE is useless (at least with respect to keyboards). Modern USB host
+                // controllers should never have a problem keeping up with slow HID devices.
+                //
+                // To implement this correctly it would require integration with higher-level
+                // functions to handle report expiry.
+                // See https://www.usb.org/sites/default/files/documents/hid1_11.pdf 7.2.4
+                //
+                // Each Report ID can be configured independently.
                 xfer.reject().ok(); // Not supported for now
             }
             _ => {}
@@ -228,7 +323,29 @@ impl<B: UsbBus> UsbClass<B> for HIDClass<'_, B> {
                 xfer.accept().ok();
             }
             HID_REQ_SET_REPORT => {
-                xfer.reject().ok(); // Not supported for now
+                let report_type = ((req.value >> 8) as u8).into();
+                let report_id = (req.value & 0xFF) as u8;
+                let len = req.length as usize;
+
+                // Validate that the incoming data isn't too large for the buffer
+                if len > CONTROL_BUF_LEN {
+                    self.set_report_buf = None;
+                    xfer.reject().ok();
+                } else {
+                    let mut buf: [u8; CONTROL_BUF_LEN] = [0; CONTROL_BUF_LEN];
+                    buf.copy_from_slice(&xfer.data()[..len]);
+
+                    // Overwrite previous buffer even if unused
+                    self.set_report_buf = Some(Report {
+                        info: ReportInfo {
+                            report_type,
+                            report_id,
+                            len,
+                        },
+                        buf,
+                    });
+                    xfer.accept().ok();
+                }
             }
             _ => {
                 xfer.reject().ok();


### PR DESCRIPTION
- GET_REPORT is significantly more complicated to implement with the
  current API, will leave for a future PR as the control request should
  be serviced asap (would have to have a cached value for every HID
  report id)
- Adds pull_raw_report which is an optional api
  * If you don't call it, the data will be replaced the next time there
    is a SET_REPORT for this interface. It's possible to get a
    SET_REPORT for each Report Id.
  * Using a 128 byte buffer (which is the same as usb-device). This
    should work fine until usb-device has true USB HiSpeed support. At
    which point we may want a more clever way to set this at compile
    time. The keyboard SET_REPORT, for example, only uses 1 byte.
- Includes note for GET/SET_IDLE future implementors (it's possible, but
  not really worth doing imo)