### PR TITLE
6kro fix

### DIFF
--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -58,10 +58,13 @@ pub struct MouseReport {
         (usage_page = KEYBOARD, usage_min = 0xE0, usage_max = 0xE7) = {
             #[packed_bits 8] #[item_settings data,variable,absolute] modifier=input;
         };
+        (usage_min = 0x00, usage_max = 0xFF) = {
+            #[item_settings constant,variable,absolute] reserved=input;
+        };
         (usage_page = LEDS, usage_min = 0x01, usage_max = 0x05) = {
             #[packed_bits 5] #[item_settings data,variable,absolute] leds=output;
         };
-        (usage_page = KEYBOARD, usage_min = 0x00, usage_max = 0x65) = {
+        (usage_page = KEYBOARD, usage_min = 0x00, usage_max = 0xDD) = {
             #[item_settings data,array,absolute] keycodes=input;
         };
     }
@@ -69,6 +72,7 @@ pub struct MouseReport {
 #[allow(dead_code)]
 pub struct KeyboardReport {
     pub modifier: u8,
+    pub reserved: u8,
     pub leds: u8,
     pub keycodes: [u8; 6],
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,22 +222,30 @@ mod tests {
             0x75, 0x01, // Report Size (1)
             0x95, 0x08, // Report count (8)
             0x81, 0x02, // Input (Data, Variable, Absolute)
+            0x19, 0x00, // Usage Minimum (0)
+            0x29, 0xFF, // Usage Maximum (255)
+            0x26, 0xFF, 0x00, // Logical Maximum (255)
+            0x75, 0x08, // Report Size (8)
+            0x95, 0x01, // Report Count (1)
+            0x81, 0x03, // Input (Const, Variable, Absolute)
             0x05, 0x08, // Usage Page (LEDs)
             0x19, 0x01, // Usage Minimum (1)
             0x29, 0x05, // Usage Maximum (5)
+            0x25, 0x01, // Logical Maximum (1)
+            0x75, 0x01, // Report Size (1)
             0x95, 0x05, // Report Count (5)
             0x91, 0x02, // Output (Data, Variable, Absolute)
             0x95, 0x03, // Report Count (3)
             0x91, 0x03, // Output (Constant, Variable, Absolute)
             0x05, 0x07, // Usage Page (Key Codes)
             0x19, 0x00, // Usage Minimum (0)
-            0x29, 0x65, // Usage Maximum (101)
+            0x29, 0xDD, // Usage Maximum (221)
             0x26, 0xFF, 0x00, // Logical Maximum (255)
             0x75, 0x08, // Report Size (8)
             0x95, 0x06, // Report Count (6)
             0x81, 0x00, // Input (Data, Array, Absolute)
             0xc0, // End Collection
         ];
-        assert_eq!(KeyboardReport::desc()[0..51], expected[0..51]);
+        assert_eq!(KeyboardReport::desc(), expected);
     }
 }


### PR DESCRIPTION
Fix compatibility issues with Keyboard HID descriptor.
Should be boot-mode compliant now.