### PR TITLE
Remove serialization from large byte arrays over 32 bytes long

### DIFF
--- a/macros/src/packer.rs
+++ b/macros/src/packer.rs
@@ -58,9 +58,12 @@ pub fn gen_serializer(fields: Vec<ReportUnaryField>, typ: MainItemKind) -> Resul
             8 => { // u8 / i8
                 if field.descriptor_item.report_count == 1 {
                     elems.push(make_unary_serialize_invocation(8, field.ident.clone(), signed));
-                } else {
+                } else if field.descriptor_item.report_count <= 32 {
                     let ident = field.ident.clone();
                     elems.push(quote!({ s.serialize_element(&self.#ident)?; }));
+                } else {
+                    // XXX - don't attempt to serialize arrays larger than 32
+                    //       (not supported by serde, yet)
                 }
                 Ok(())
             },

--- a/src/hid_class.rs
+++ b/src/hid_class.rs
@@ -155,10 +155,10 @@ impl<B: UsbBus> UsbClass<B> for HIDClass<'_, B> {
         )?;
 
         if let Some(ep) = &self.out_ep {
-            writer.endpoint(&ep)?;
+            writer.endpoint(ep)?;
         }
         if let Some(ep) = &self.in_ep {
-            writer.endpoint(&ep)?;
+            writer.endpoint(ep)?;
         }
         Ok(())
     }


### PR DESCRIPTION
- Required to handle 64 byte raw reports
- Fixes issue #20 