### PR TITLE
Pin dep syn to avoid breakage on 1.0.76

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -20,4 +20,4 @@ usbd-hid-descriptors = { path = "../descriptors", version = ">=0.1.1" }
 
 [dependencies.syn]
 features = ["extra-traits", "full"]
-version = "1.0"
+version = "=1.0.75"


### PR DESCRIPTION
The latest version of syn breaks half of the tests.
Pin the last working version until we can work out why.

Failed test output:
```
 ---- tests::test_custom_const stdout ----
thread 'tests::test_custom_const' panicked at 'assertion failed: `(left == right)`
  left: `[6, 0, 255, 9, 1, 161, 1, 25, 1, 41, 3, 21, 0, 38, 255, 0, 117, 8, 149, 1, 129, 2, 192]`,
 right: `[6, 0, 255, 9, 1, 161, 1, 25, 1, 41, 3, 21, 0, 38, 255, 0, 117, 8, 149, 1, 129, 6, 192]`', src/lib.rs:156:9

---- tests::test_keyboard_descriptor stdout ----
thread 'tests::test_keyboard_descriptor' panicked at 'assertion failed: `(left == right)`
  left: `[5, 1, 9, 6, 161, 1, 5, 7, 25, 224, 41, 231, 21, 0, 38, 255, 0, 117, 8, 149, 1, 129, 2, 25, 0, 41, 255, 129, 2, 5, 8, 25, 1, 41, 5, 145, 2, 5, 7, 25, 0, 41, 221, 149, 6, 129, 2, 192]`,
 right: `[5, 1, 9, 6, 161, 1, 5, 7, 25, 224, 41, 231, 21, 0, 37, 1, 117, 1, 149, 8, 129, 2, 25, 0, 41, 255, 38, 255, 0, 117, 8, 149, 1, 129, 3, 5, 8, 25, 1, 41, 5, 37, 1, 117, 1, 149, 5, 145, 2, 149, 3, 145, 3, 5, 7, 25, 0, 41, 221, 38, 255, 0, 117, 8, 149, 6, 129, 0, 192]`', src/lib.rs:250:9

---- tests::test_mouse_descriptor stdout ----
thread 'tests::test_mouse_descriptor' panicked at 'assertion failed: `(left == right)`
  left: `[5, 1, 9, 2, 161, 1, 9, 1, 161, 0, 5, 9, 25, 1, 41, 8, 21, 0, 38, 255, 0, 117, 8, 149, 1, 129, 2, 5, 1, 9, 48, 23]`,
 right: `[5, 1, 9, 2, 161, 1, 9, 1, 161, 0, 5, 9, 25, 1, 41, 8, 21, 0, 37, 1, 117, 1, 149, 8, 129, 2, 5, 1, 9, 48, 23, 129]`', src/lib.rs:209:9

---- tests::test_custom_packed_bits stdout ----
thread 'tests::test_custom_packed_bits' panicked at 'assertion failed: `(left == right)`
  left: `[133, 1, 21, 0, 38, 255, 0, 117, 8, 149, 1, 129, 2, 39, 255, 255, 0, 0, 117, 16, 129, 2, 38, 255, 0, 117, 8, 149, 3, 129, 2]`,
 right: `[133, 1, 21, 0, 37, 1, 117, 1, 149, 3, 129, 2, 149, 5, 129, 3, 149, 9, 129, 2, 149, 7, 129, 3, 149, 20, 129, 2, 149, 4, 129, 3]`', src/lib.rs:197:9
 ```