### PR TITLE
Used a Visitor to collect item_settings.

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -19,5 +19,5 @@ serde = { version = "1.0", default-features = false }
 usbd-hid-descriptors = { path = "../descriptors", version = ">=0.1.1" }
 
 [dependencies.syn]
-features = ["extra-traits", "full"]
-version = "=1.0.75"
+features = ["extra-traits", "full", "visit"]
+version = "1.0"


### PR DESCRIPTION
The old version was dependent on syn parsing a specific tree structure for the
macro while this can work with syn versions <=1.0.75 and >=1.0.76 and hopefully
any future versions.

Should fix #32