### PR TITLE
new maybe_push_input() method to HIDClass 

### DIFF
--- a/src/hid_class.rs
+++ b/src/hid_class.rs
@@ -102,6 +102,24 @@ impl<B: UsbBus> HIDClass<'_, B> {
         }
     }
 
+    pub fn maybe_push_input<'a, IR: AsInputReport>(
+        &self,
+         mut producer: impl FnMut() -> IR,
+    ) -> Option<Result<usize>> {
+        if let Some(ep) = &self.in_ep {
+            let mut buff: [u8; 64] = [0; 64];
+            ep.maybe_write(|| {
+                let size = match serialize(&mut buff, &producer()) {
+                    Ok(l) => l,
+                    Err(_) => return Err(UsbError::BufferOverflow),
+                };
+                Ok(&buff[0..size])
+            })
+        } else {
+            Some(Err(UsbError::InvalidEndpoint))
+        }
+    }
+
     /// Tries to write an input (device-to-host) report from the given raw bytes.
     /// Data is expected to be a valid HID report for INPUT items. If report ID's
     /// were used in the descriptor, the report ID corresponding to this report


### PR DESCRIPTION
The `push_input()` API for HIDClass is a little clumsy because it returns an error if the write would block, forcing the code that invokes it to hang on to the buffer and retry later.

This is a solution, but it requires changes to the UsbBus trait ( https://github.com/mvirkkunen/usb-device/pull/78 )

I am mostly trying to start a conversation about this so options (such as the ability to check WouldBlock before calling push_input) can be discussed.