### PR TITLE
Fixing logical_minimum field from being double emitted when customized

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -522,9 +522,12 @@ impl DescCompilation {
             );
         }
         if let Some(logical_minimum) = spec.logical_min {
+            // Set to 0 to indicate that we've already set the default
+            // See handle_globals
+            self.logical_minimum = Some(0);
             self.emit_item(
                 elems,
-                ItemType::Main.into(),
+                ItemType::Global.into(),
                 GlobalItemKind::LogicalMin.into(),
                 logical_minimum as isize,
                 false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub mod hid_class;
 #[allow(unused_imports)]
 mod tests {
     use crate::descriptor::generator_prelude::*;
-    use crate::descriptor::{KeyboardReport, MouseReport};
+    use crate::descriptor::{KeyboardReport, MouseReport, SystemControlReport};
 
     // This should generate this descriptor:
     // 0x06, 0x00, 0xFF,  // Usage Page (Vendor Defined 0xFF00)
@@ -248,5 +248,24 @@ mod tests {
             0xc0, // End Collection
         ];
         assert_eq!(KeyboardReport::desc(), expected);
+    }
+
+    #[test]
+    fn test_system_control_descriptor() {
+        let expected = &[
+            0x05, 0x01, // Usage Page (Generic Desktop Ctrls)
+            0x09, 0x80, // Usage (Sys Control)
+            0xA1, 0x01, // Collection (Application)
+            0x19, 0x81, //   Usage Minimum (Sys Power Down)
+            0x29, 0xB7, //   Usage Maximum (Sys Display LCD Autoscale)
+            0x15, 0x01, //   Logical Minimum (1)
+            0x26, 0xFF, 0x00, //   Logical Maximum (255)
+            0x75, 0x08, //   Report Size (8)
+            0x95, 0x01, //   Report Count (1)
+            0x81,
+            0x00, //   Input (Data,Array,Abs,No Wrap,Linear,Preferred State,No Null Position)
+            0xC0, // End Collection
+        ];
+        assert_eq!(SystemControlReport::desc(), expected);
     }
 }


### PR DESCRIPTION
- Fixed the the logical_minimum tag to be a global
- Also added a unit test to make sure the SystemControl descriptor is
  correct