### PR TITLE
Add MediaKey::Mute

### DIFF
--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -118,6 +118,7 @@ pub enum MediaKey {
     RandomPlay = 0xB9,
     Repeat = 0xBC,
     PlayPause = 0xCD,
+    Mute = 0xE2,
     VolumeIncrement = 0xE9,
     VolumeDecrement = 0xEA,
 }


### PR DESCRIPTION
Mute is listed in https://usb.org/sites/default/files/hut1_2.pdf page 120.