### PR TITLE
Updated byteorder dependency to ~1.4 in macros/Cargo.toml

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -14,7 +14,7 @@ proc-macro = true
 [dependencies]
 quote = "1.0"
 proc-macro2 = "1.0"
-byteorder = {version = "~1.3", default-features=false }
+byteorder = {version = "~1.4", default-features=false }
 serde = { version = "1.0", default-features = false }
 usbd-hid-descriptors = { path = "../descriptors", version = ">=0.1.1" }
 


### PR DESCRIPTION
This should fix issues with *other* crates (e.g. `embedded-graphics` master branch) that expect a newer version of the `byteorder` crate.  I tested this change and it doesn't appear to impact anything (everything builds just fine 👍).