### PR TITLE
General clippy cleanup

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,6 +15,10 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --features defmt
 
   build:
     name: Build
@@ -28,6 +32,10 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: build
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --features defmt
 
   fmt:
     name: Rustfmt
@@ -58,6 +66,10 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --features defmt -- -D warnings
 
   doc:
     name: Doc Check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,3 +21,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,9 @@
+[workspace]
+members = [
+    "macros",
+    "descriptors",
+]
+
 [package]
 name = "usbd-hid"
 description = "A HID class for use with usb-device."
@@ -5,7 +11,7 @@ version = "0.6.1"
 keywords = ["hid", "no-std", "usb-device"]
 license = "MIT OR Apache-2.0"
 authors = ["twitchyliquid64"]
-edition = "2018"
+edition = "2021"
 repository = "https://github.com/twitchyliquid64/usbd-hid"
 
 

--- a/descriptors/Cargo.toml
+++ b/descriptors/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["no-std", "hid"]
 license = "MIT OR Apache-2.0"
 name = "usbd-hid-descriptors"
 version = "0.1.2"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-bitfield = "~0.13"
+bitfield = "~0.14"

--- a/descriptors/src/lib.rs
+++ b/descriptors/src/lib.rs
@@ -18,9 +18,9 @@ pub enum GlobalItemKind {
     ReportCount = 9,
 }
 
-impl Into<u8> for GlobalItemKind {
-    fn into(self) -> u8 {
-        unsafe { core::mem::transmute(self) }
+impl From<GlobalItemKind> for u8 {
+    fn from(kind: GlobalItemKind) -> u8 {
+        kind as u8
     }
 }
 
@@ -42,9 +42,9 @@ pub enum LocalItemKind {
     Delimiter = 10,
 }
 
-impl Into<u8> for LocalItemKind {
-    fn into(self) -> u8 {
-        unsafe { core::mem::transmute(self) }
+impl From<LocalItemKind> for u8 {
+    fn from(kind: LocalItemKind) -> u8 {
+        kind as u8
     }
 }
 
@@ -61,19 +61,21 @@ pub enum MainItemKind {
     EndCollection = 0b1100,
 }
 
-impl Into<u8> for MainItemKind {
-    fn into(self) -> u8 {
-        unsafe { core::mem::transmute(self) }
+impl From<MainItemKind> for u8 {
+    fn from(kind: MainItemKind) -> u8 {
+        kind as u8
     }
 }
 
 impl Default for MainItemKind {
-    fn default() -> Self { MainItemKind::Input }
+    fn default() -> Self {
+        MainItemKind::Input
+    }
 }
 
-impl Into<MainItemKind> for String {
-    fn into(self) -> MainItemKind {
-        match self.as_str() {
+impl From<String> for MainItemKind {
+    fn from(s: String) -> Self {
+        match s.as_str() {
             "feature" => MainItemKind::Feature,
             "output" => MainItemKind::Output,
             "collection" => MainItemKind::Collection,
@@ -83,7 +85,6 @@ impl Into<MainItemKind> for String {
         }
     }
 }
-
 
 /// ItemType describes types of items as described in section 6.2.2.7
 /// 'Report Descriptor' of the spec, version 1.11.
@@ -96,16 +97,17 @@ pub enum ItemType {
     Local = 2,
 }
 
-impl Into<u8> for ItemType {
-    fn into(self) -> u8 {
-        unsafe { core::mem::transmute(self) }
+impl From<ItemType> for u8 {
+    fn from(kind: ItemType) -> u8 {
+        kind as u8
     }
 }
 
 impl Default for ItemType {
-    fn default() -> Self { ItemType::Main }
+    fn default() -> Self {
+        ItemType::Main
+    }
 }
-
 
 bitfield! {
     /// MainItemSetting describes the bits which configure invariants on a MainItem.

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -6,15 +6,15 @@ keywords = ["no-std", "usb-device"]
 license = "MIT OR Apache-2.0"
 name = "usbd-hid-macros"
 version = "0.6.0"
-edition = "2018"
+edition = "2021"
 
 [lib]
 proc-macro = true
 
 [dependencies]
-quote = "1.0"
+byteorder = { version = "~1.4", default-features = false }
 proc-macro2 = "1.0"
-byteorder = {version = "~1.4", default-features=false }
+quote = "1.0"
 serde = { version = "1.0", default-features = false }
 usbd-hid-descriptors = { path = "../descriptors", version = ">=0.1.2" }
 

--- a/macros/src/item.rs
+++ b/macros/src/item.rs
@@ -1,8 +1,8 @@
 extern crate usbd_hid_descriptors;
 
-use syn::{parse, Field, Fields, Type, Expr, Result, Ident, ExprLit, Lit, TypePath};
-use usbd_hid_descriptors::*;
 use crate::spec::*;
+use syn::{parse, Expr, ExprLit, Field, Fields, Ident, Lit, Result, Type, TypePath};
+use usbd_hid_descriptors::*;
 
 // MainItem describes all the mandatory data points of a Main item.
 #[derive(Debug, Default, Clone)]
@@ -27,9 +27,10 @@ pub fn analyze_field(field: Field, ft: Type, item: &ItemSpec) -> Result<ReportUn
     let (p, size) = parse_type(&field, ft)?;
 
     if p.path.segments.len() != 1 {
-        return Err(
-            parse::Error::new(field.ident.unwrap().span(), "`#[gen_hid_descriptor]` internal error when unwrapping type")
-        );
+        return Err(parse::Error::new(
+            field.ident.unwrap().span(),
+            "`#[gen_hid_descriptor]` internal error when unwrapping type",
+        ));
     }
     let type_ident = p.path.segments[0].ident.clone();
 
@@ -39,40 +40,48 @@ pub fn analyze_field(field: Field, ft: Type, item: &ItemSpec) -> Result<ReportUn
     let type_setter: Option<fn(&mut ReportUnaryField, usize)> = match sign {
         "u" => Some(set_unsigned_unary_item),
         "i" => Some(set_signed_unary_item),
-        &_ => None
+        &_ => None,
     };
 
     if bit_width.is_err() || type_setter.is_none() {
-        return Err(
-            parse::Error::new(type_ident.span(), "`#[gen_hid_descriptor]` type not supported")
-        )
+        return Err(parse::Error::new(
+            type_ident.span(),
+            "`#[gen_hid_descriptor]` type not supported",
+        ));
     }
     let bit_width = bit_width.unwrap();
 
     if bit_width >= 64 {
-        return Err(
-            parse::Error::new(type_ident.span(), "`#[gen_hid_descriptor]` integer larger than 64 is not supported in ssmarshal")
-        )
+        return Err(parse::Error::new(
+            type_ident.span(),
+            "`#[gen_hid_descriptor]` integer larger than 64 is not supported in ssmarshal",
+        ));
     }
 
     let mut output = unary_item(field.ident.clone().unwrap(), item.kind, bit_width);
 
-    if let Some(want_bits) = item.want_bits {  // bitpack
+    if let Some(want_bits) = item.want_bits {
+        // bitpack
         output.descriptor_item.logical_minimum = 0;
         output.descriptor_item.logical_maximum = 1;
         output.descriptor_item.report_count = want_bits;
         output.descriptor_item.report_size = 1;
         let width = output.bit_width * size;
         if width < want_bits as usize {
-            return Err(
-                parse::Error::new(field.ident.unwrap().span(), format!("`#[gen_hid_descriptor]` not enough space, missing {} bit(s)", want_bits as usize - width))
-            )
+            return Err(parse::Error::new(
+                field.ident.unwrap().span(),
+                format!(
+                    "`#[gen_hid_descriptor]` not enough space, missing {} bit(s)",
+                    want_bits as usize - width
+                ),
+            ));
         }
         let remaining_bits = width as u16 - want_bits;
         if remaining_bits > 0 {
             output.descriptor_item.padding_bits = Some(remaining_bits);
         }
-    } else { // array of reports
+    } else {
+        // array of reports
         type_setter.unwrap()(&mut output, bit_width);
         output.descriptor_item.report_count *= size as u16;
     }
@@ -85,34 +94,33 @@ fn parse_type(field: &Field, ft: Type) -> Result<(TypePath, usize)> {
         Type::Array(a) => {
             let mut size: usize = 0;
 
-            if let Expr::Lit(ExprLit { lit, .. }) = a.len {
-                if let Lit::Int(lit) = lit {
-                    if let Ok(num) = lit.base10_parse::<usize>() {
-                        size = num;
-                    }
+            if let Expr::Lit(ExprLit {
+                lit: Lit::Int(lit), ..
+            }) = a.len
+            {
+                if let Ok(num) = lit.base10_parse::<usize>() {
+                    size = num;
                 }
             }
             if size == 0 {
-                Err(
-                    parse::Error::new(field.ident.as_ref().unwrap().span(), "`#[gen_hid_descriptor]` array has invalid length")
-                )
+                Err(parse::Error::new(
+                    field.ident.as_ref().unwrap().span(),
+                    "`#[gen_hid_descriptor]` array has invalid length",
+                ))
             } else {
-                Ok((parse_type(&field, *a.elem)?.0, size))
+                Ok((parse_type(field, *a.elem)?.0, size))
             }
         }
-        Type::Path(p) => {
-            Ok((p, 1))
-        }
-        _ => {
-            Err(
-                parse::Error::new(field.ident.as_ref().unwrap().span(),"`#[gen_hid_descriptor]` cannot handle field type")
-            )
-        }
+        Type::Path(p) => Ok((p, 1)),
+        _ => Err(parse::Error::new(
+            field.ident.as_ref().unwrap().span(),
+            "`#[gen_hid_descriptor]` cannot handle field type",
+        )),
     }
 }
 
 fn set_signed_unary_item(out: &mut ReportUnaryField, bit_width: usize) {
-    let bound = 2u32.pow((bit_width-1) as u32) as isize - 1;
+    let bound = 2u32.pow((bit_width - 1) as u32) as isize - 1;
     out.descriptor_item.logical_minimum = -bound;
     out.descriptor_item.logical_maximum = bound;
 }
@@ -123,10 +131,10 @@ fn set_unsigned_unary_item(out: &mut ReportUnaryField, bit_width: usize) {
 }
 
 fn unary_item(id: Ident, kind: MainItemKind, bit_width: usize) -> ReportUnaryField {
-    ReportUnaryField{
+    ReportUnaryField {
         ident: id,
         bit_width,
-        descriptor_item: MainItem{
+        descriptor_item: MainItem {
             kind,
             logical_minimum: 0,
             logical_maximum: 0,
@@ -144,5 +152,8 @@ pub fn field_decl(fields: &Fields, name: String) -> Field {
             return field.clone();
         }
     }
-    panic!("internal error: could not find field {} which should exist", name)
+    panic!(
+        "internal error: could not find field {} which should exist",
+        name
+    )
 }


### PR DESCRIPTION
- clippy and test were not being run on descriptors and macros sub-dirs
  * Added descriptors and macros as workspace members (cargo clippy will now catch everything)
  * Added cargo test --all to GitHub Actions
- Fixed lots of clippy warnings
  * Left a few alone (including one new clippy bug) as it's unclear if it's actually an improvement (or makes logical sense in the particular case)
- Ignore doc tests that don't compile (macros can only be used externally to macro crates)
- Small Cargo.toml cleanups
- Update to 2021 edition
- cargo fmt --all