### PR TITLE
Add default KeyboardReport function

### DIFF
--- a/descriptors/src/lib.rs
+++ b/descriptors/src/lib.rs
@@ -52,8 +52,9 @@ impl From<LocalItemKind> for u8 {
 /// 'Report Descriptor' of the spec, version 1.11.
 #[repr(u8)]
 #[allow(unused)]
-#[derive(Copy, Debug, Clone, Eq, PartialEq)]
+#[derive(Copy, Debug, Default, Clone, Eq, PartialEq)]
 pub enum MainItemKind {
+    #[default]
     Input = 0b1000,
     Output = 0b1001,
     Feature = 0b1011,
@@ -64,12 +65,6 @@ pub enum MainItemKind {
 impl From<MainItemKind> for u8 {
     fn from(kind: MainItemKind) -> u8 {
         kind as u8
-    }
-}
-
-impl Default for MainItemKind {
-    fn default() -> Self {
-        MainItemKind::Input
     }
 }
 
@@ -90,8 +85,9 @@ impl From<String> for MainItemKind {
 /// 'Report Descriptor' of the spec, version 1.11.
 #[repr(u8)]
 #[allow(unused)]
-#[derive(Copy, Debug, Clone, Eq, PartialEq)]
+#[derive(Copy, Debug, Default, Clone, Eq, PartialEq)]
 pub enum ItemType {
+    #[default]
     Main = 0,
     Global = 1,
     Local = 2,
@@ -100,12 +96,6 @@ pub enum ItemType {
 impl From<ItemType> for u8 {
     fn from(kind: ItemType) -> u8 {
         kind as u8
-    }
-}
-
-impl Default for ItemType {
-    fn default() -> Self {
-        ItemType::Main
     }
 }
 

--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -104,7 +104,7 @@ impl KeyboardReport {
 #[allow(unused)]
 #[non_exhaustive]
 #[derive(Copy, Debug, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "defmt-impl", derive(defmt::Format))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum KeyboardUsage {
     // 0x00: Reserved
     /// Keyboard ErrorRollOver (Footnote 1)

--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -83,6 +83,17 @@ pub struct KeyboardReport {
     pub keycodes: [u8; 6],
 }
 
+impl KeyboardReport {
+    pub const fn default() -> Self {
+        Self {
+            modifier: 0,
+            reserved: 0,
+            leds: 0,
+            keycodes: [0u8; 6],
+        }
+    }
+}
+
 /// KeyboardUsage describes the key codes to be used in implementing a USB keyboard.
 ///
 /// The usage type of all key codes is Selectors, except for the modifier keys


### PR DESCRIPTION
Adds a helper function for creating a default `KeyboardReport`.

Also fixes a small typo for the `defmt` feature.