### PR TITLE
macros: convert to no_std

### DIFF
--- a/descriptors/src/lib.rs
+++ b/descriptors/src/lib.rs
@@ -52,8 +52,9 @@ impl From<LocalItemKind> for u8 {
 /// 'Report Descriptor' of the spec, version 1.11.
 #[repr(u8)]
 #[allow(unused)]
-#[derive(Copy, Debug, Clone, Eq, PartialEq)]
+#[derive(Copy, Debug, Default, Clone, Eq, PartialEq)]
 pub enum MainItemKind {
+    #[default]
     Input = 0b1000,
     Output = 0b1001,
     Feature = 0b1011,
@@ -64,12 +65,6 @@ pub enum MainItemKind {
 impl From<MainItemKind> for u8 {
     fn from(kind: MainItemKind) -> u8 {
         kind as u8
-    }
-}
-
-impl Default for MainItemKind {
-    fn default() -> Self {
-        MainItemKind::Input
     }
 }
 
@@ -90,8 +85,9 @@ impl From<String> for MainItemKind {
 /// 'Report Descriptor' of the spec, version 1.11.
 #[repr(u8)]
 #[allow(unused)]
-#[derive(Copy, Debug, Clone, Eq, PartialEq)]
+#[derive(Copy, Debug, Default, Clone, Eq, PartialEq)]
 pub enum ItemType {
+    #[default]
     Main = 0,
     Global = 1,
     Local = 2,
@@ -100,12 +96,6 @@ pub enum ItemType {
 impl From<ItemType> for u8 {
     fn from(kind: ItemType) -> u8 {
         kind as u8
-    }
-}
-
-impl Default for ItemType {
-    fn default() -> Self {
-        ItemType::Main
     }
 }
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -17,6 +17,8 @@ proc-macro2 = "1.0"
 quote = "1.0"
 serde = { version = "1.0", default-features = false }
 usbd-hid-descriptors = { path = "../descriptors", version = ">=0.1.2" }
+hashbrown = "0.13"
+log = "0.4"
 
 [dependencies.syn]
 features = ["extra-traits", "full", "visit"]

--- a/macros/src/item.rs
+++ b/macros/src/item.rs
@@ -1,5 +1,6 @@
 extern crate usbd_hid_descriptors;
 
+use alloc::{format, string::{String, ToString}};
 use crate::spec::*;
 use syn::{parse, Expr, ExprLit, Field, Fields, Ident, Lit, Result, Type, TypePath};
 use usbd_hid_descriptors::*;

--- a/macros/src/item.rs
+++ b/macros/src/item.rs
@@ -1,7 +1,10 @@
 extern crate usbd_hid_descriptors;
 
-use alloc::{format, string::{String, ToString}};
 use crate::spec::*;
+use alloc::{
+    format,
+    string::{String, ToString},
+};
 use syn::{parse, Expr, ExprLit, Field, Fields, Ident, Lit, Result, Type, TypePath};
 use usbd_hid_descriptors::*;
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,8 +1,11 @@
 //! Internal implementation details of usbd-hid.
+#![no_std]
 
+extern crate alloc;
 extern crate proc_macro;
 extern crate usbd_hid_descriptors;
 
+use alloc::{boxed::Box, vec, vec::Vec};
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::quote;

--- a/macros/src/packer.rs
+++ b/macros/src/packer.rs
@@ -1,6 +1,8 @@
 extern crate usbd_hid_descriptors;
 use usbd_hid_descriptors::*;
 
+use alloc::vec::Vec;
+
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{parse, Ident, Index, Result};

--- a/macros/src/spec.rs
+++ b/macros/src/spec.rs
@@ -6,8 +6,8 @@ use syn::punctuated::Punctuated;
 use syn::{parse, Attribute, Expr, ExprAssign, ExprPath, Path, Result, Token};
 use syn::{Block, ExprBlock, ExprLit, ExprTuple, Lit, Stmt};
 
-use std::collections::HashMap;
-use std::string::String;
+use hashbrown::HashMap;
+use alloc::{borrow::ToOwned, format, string::{String, ToString}, vec, vec::Vec};
 use syn::spanned::Spanned;
 use syn::visit::Visit;
 use usbd_hid_descriptors::*;
@@ -137,7 +137,7 @@ impl GroupSpec {
 
 impl IntoIterator for GroupSpec {
     type Item = String;
-    type IntoIter = std::vec::IntoIter<Self::Item>;
+    type IntoIter = vec::IntoIter<Self::Item>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.field_order.into_iter()
@@ -353,7 +353,7 @@ fn parse_item_attrs(attrs: Vec<Attribute>) -> (Option<MainItemSetting>, Option<u
                     }
                 }
                 if packed_bits.is_none() {
-                    println!("WARNING!: bitfield attribute specified but failed to read number of bits from token!");
+                    log::warn!("bitfield attribute specified but failed to read number of bits from token!");
                 }
             }
 
@@ -385,7 +385,7 @@ fn parse_item_attrs(attrs: Vec<Attribute>) -> (Option<MainItemSetting>, Option<u
 
                             "volatile" => out.set_volatile(true),
                             "not_volatile" => out.set_volatile(false),
-                            p => println!("WARNING: Unknown item_settings parameter: {}", p),
+                            p => log::warn!("Unknown item_settings parameter: {p}"),
                         }
                     }
                 }
@@ -396,15 +396,13 @@ fn parse_item_attrs(attrs: Vec<Attribute>) -> (Option<MainItemSetting>, Option<u
                     if let proc_macro2::TokenTree::Ident(id) = setting {
                         match id.to_string().as_str() {
                             "allow_short" => quirks.allow_short_form = true,
-                            p => println!("WARNING: Unknown item_settings parameter: {}", p),
+                            p => log::warn!("Unknown item_settings parameter: {p}"),
                         }
                     }
                 }
             }
 
-            p => {
-                println!("WARNING: Unknown item attribute: {}", p);
-            }
+            p => log::warn!("Unknown item attribute: {p}"),
         }
     }
 

--- a/macros/src/spec.rs
+++ b/macros/src/spec.rs
@@ -6,8 +6,14 @@ use syn::punctuated::Punctuated;
 use syn::{parse, Attribute, Expr, ExprAssign, ExprPath, Path, Result, Token};
 use syn::{Block, ExprBlock, ExprLit, ExprTuple, Lit, Stmt};
 
+use alloc::{
+    borrow::ToOwned,
+    format,
+    string::{String, ToString},
+    vec,
+    vec::Vec,
+};
 use hashbrown::HashMap;
-use alloc::{borrow::ToOwned, format, string::{String, ToString}, vec, vec::Vec};
 use syn::spanned::Spanned;
 use syn::visit::Visit;
 use usbd_hid_descriptors::*;


### PR DESCRIPTION
Converts the `macros` crate to `no_std`. Avoids indirectly including `std` library in a `no_std` crate.