### PR TITLE
descriptors: convert crate to no_std

### DIFF
--- a/descriptors/src/lib.rs
+++ b/descriptors/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 use bitfield::bitfield;
 
 /// GlobalItemKind describes global item tags as described in section 6.2.2.7
@@ -68,9 +70,9 @@ impl From<MainItemKind> for u8 {
     }
 }
 
-impl From<String> for MainItemKind {
-    fn from(s: String) -> Self {
-        match s.as_str() {
+impl From<&str> for MainItemKind {
+    fn from(s: &str) -> Self {
+        match s {
             "feature" => MainItemKind::Feature,
             "output" => MainItemKind::Output,
             "collection" => MainItemKind::Collection,

--- a/macros/src/spec.rs
+++ b/macros/src/spec.rs
@@ -519,7 +519,7 @@ impl GroupSpec {
     fn from_field(&mut self, input: ParseStream, field: Expr) -> Result<()> {
         if let Some(i) = maybe_parse_kv(field.clone()) {
             let (name, item_kind, settings, bits, quirks) = i;
-            self.set_item(name, item_kind.into(), settings, bits, quirks);
+            self.set_item(name, item_kind.as_str().into(), settings, bits, quirks);
             return Ok(());
         };
         match parse_group_spec(input, field) {


### PR DESCRIPTION
Converts the `descriptors` crate to `no_std` to avoid indirect dependency on the `std` library in a `no_std` crate.