### PR TITLE
Allow depending on byteorder 1.5

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 proc-macro = true
 
 [dependencies]
-byteorder = { version = "~1.4", default-features = false }
+byteorder = { version = "1.5", default-features = false }
 proc-macro2 = "1.0"
 quote = "1.0"
 serde = { version = "1.0", default-features = false }


### PR DESCRIPTION
Update the macros dependency to allow byteorder 1.5 to be used, which was released ~6 months ago.  This is needed to make usbd-hid usable with other crates that use byteorder 1.5 in their macros.