### PR TITLE
Revert "new maybe_push_input() method"

### DIFF
--- a/src/hid_class.rs
+++ b/src/hid_class.rs
@@ -408,24 +408,6 @@ impl<B: UsbBus> HIDClass<'_, B> {
         }
     }
 
-    pub fn maybe_push_input<'a, IR: AsInputReport>(
-        &self,
-         mut producer: impl FnMut() -> IR,
-    ) -> Option<Result<usize>> {
-        if let Some(ep) = &self.in_ep {
-            let mut buff: [u8; 64] = [0; 64];
-            ep.maybe_write(|| {
-                let size = match serialize(&mut buff, &producer()) {
-                    Ok(l) => l,
-                    Err(_) => return Err(UsbError::BufferOverflow),
-                };
-                Ok(&buff[0..size])
-            })
-        } else {
-            Some(Err(UsbError::InvalidEndpoint))
-        }
-    }
-
     /// Tries to write an input (device-to-host) report from the given raw bytes.
     /// Data is expected to be a valid HID report for INPUT items. If report ID's
     /// were used in the descriptor, the report ID corresponding to this report


### PR DESCRIPTION
This reverts commit c1210a947d5474d138f5eff89210cedef1bc870e. (#34) This commit breaks the build since it attempts to use `EndpointIn` methods from a PR that were never landed in the usb-device crate: https://github.com/rust-embedded-community/usb-device/pull/78