### PR TITLE
Add FIDO alliance page

### DIFF
--- a/macros/src/spec.rs
+++ b/macros/src/spec.rs
@@ -176,6 +176,7 @@ pub fn try_resolve_constant(key_name: String, path: String) -> Option<u32> {
         ("usage_page", "DIGITIZER") => Some(0x0D),
         ("usage_page", "ALPHANUMERIC_DISPLAY") => Some(0x14),
         ("usage_page", "BARCODE_SCANNER") => Some(0x8C),
+        ("usage_page", "FIDO_ALLIANCE") => Some(0xF1D0),
         ("usage_page", "VENDOR_DEFINED_START") => Some(0xFF00),
         ("usage_page", "VENDOR_DEFINED_END") => Some(0xFFFF),
 
@@ -227,6 +228,11 @@ pub fn try_resolve_constant(key_name: String, path: String) -> Option<u32> {
         ("usage", "HEADPHONE") => Some(0x05),
         ("usage", "GRAPHIC_EQUALIZER") => Some(0x06),
         ("usage", "AC_PAN") => Some(0x0238),
+
+        // FIDO Alliance usage_page
+        ("usage", "U2F_AUTHENTICATOR_DEVICE") => Some(0x1),
+        ("usage", "INPUT_REPORT_DATA") => Some(0x20),
+        ("usage", "OUTPUT_REPORT_DATA") => Some(0x21),
 
         (_, _) => None,
     }

--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -978,3 +978,21 @@ impl From<u8> for SystemControlKey {
         }
     }
 }
+
+/// CtapReport describes a report and its companion descriptor that can be
+/// used to present a FIDO-compatible authenticator device to the host.
+#[gen_hid_descriptor(
+    (collection = APPLICATION, usage_page = FIDO_ALLIANCE, usage = U2F_AUTHENTICATOR_DEVICE) = {
+        (usage = INPUT_REPORT_DATA, logical_min = 0x0) = {
+            #[item_settings data,variable,absolute] data_in=input;
+        };
+        (usage = OUTPUT_REPORT_DATA, logical_min = 0x0) = {
+            #[item_settings data,variable,absolute] data_out=output;
+        };
+    }
+)]
+#[allow(dead_code)]
+pub struct CtapReport {
+    pub data_in: [u8; 64],
+    pub data_out: [u8; 64],
+}


### PR DESCRIPTION
This will support the CTAP and CTAP2 protocols used for 2-factor authentication devices.