### PR TITLE
macros: don't use `>=` in version selector.

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -16,7 +16,7 @@ byteorder = { version = "1.5", default-features = false }
 proc-macro2 = "1.0"
 quote = "1.0"
 serde = { version = "1.0", default-features = false }
-usbd-hid-descriptors = { path = "../descriptors", version = ">=0.8.0" }
+usbd-hid-descriptors = { path = "../descriptors", version = "0.8.0" }
 hashbrown = "0.13"
 log = "0.4"
 


### PR DESCRIPTION
`>=0.8.0` matches literally any higher version, with possible breaking changes: 0.8.x, 0.9.x, 1.x, 2.x... This will cause the build of usbd-hid-macros to break when 0.9.0 or higher is relased.

This already happened. -macros v0.6 had `>=0.1.2`, which broke today when you released v0.8.0, breaking embassy: https://github.com/embassy-rs/embassy/pull/3181 .

