### PR TITLE
Add std feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ usbd-hid-macros = { path = "macros", version = "0.8.2" }
 [features]
 # Add defmt Format support enums and structs
 defmt = ["dep:defmt", "usb-device/defmt"]
+std = ["serde/std", "ssmarshal/std"]


### PR DESCRIPTION
Without this feature, it is not possible to use usbd-hid in a larger crate which enables the std feature of serde, since this needs to be coordinated with enabling the std feature of ssmarshal. The workaround is to make the larger crate also depend on ssmarshal just to enable the std feature. This PR makes this more convenient by enabling the std feature on usbd-hid directly.