### PR TITLE
Fix operator precedence in descriptor length serialization

### DIFF
--- a/macros/src/spec.rs
+++ b/macros/src/spec.rs
@@ -492,14 +492,14 @@ fn maybe_parse_kv(
 
 struct AttributeCollector(Vec<Attribute>);
 
-impl<'ast> AttributeCollector {
+impl AttributeCollector {
     fn new() -> Self {
         Self(vec![])
     }
 
     /// Recursively finds all Attributes contained by an Expr.
     /// Returns None when no attributes are found.
-    pub fn all(expr: &'ast Expr) -> Option<Vec<Attribute>> {
+    pub fn all(expr: &'_ Expr) -> Option<Vec<Attribute>> {
         let mut visitor = Self::new();
         visitor.visit_expr(expr);
         if visitor.0.is_empty() {

--- a/src/hid_class.rs
+++ b/src/hid_class.rs
@@ -556,7 +556,7 @@ impl<B: UsbBus> UsbClass<B> for HIDClass<'_, B> {
                 HID_DESC_DESCTYPE_HID_REPORT,
                 // HID report descriptor size,
                 (self.report_descriptor.len() & 0xFF) as u8,
-                (self.report_descriptor.len() >> 8 & 0xFF) as u8,
+                ((self.report_descriptor.len() >> 8) & 0xFF) as u8,
             ],
         )?;
 
@@ -600,7 +600,7 @@ impl<B: UsbBus> UsbClass<B> for HIDClass<'_, B> {
                             HID_DESC_DESCTYPE_HID_REPORT,
                             // HID report descriptor size,
                             (self.report_descriptor.len() & 0xFF) as u8,
-                            (self.report_descriptor.len() >> 8 & 0xFF) as u8,
+                            ((self.report_descriptor.len() >> 8) & 0xFF) as u8,
                         ];
                         xfer.accept_with(buf).ok();
                     }


### PR DESCRIPTION
Thank you for the work on this crate!

I believe the serialization of descriptor lengths requires an extra pair of parentheses, as Clippy hints to with its [`precedence` lint](https://rust-lang.github.io/rust-clippy/master/index.html#precedence). The [`&` operator has higher precedence than `>>`](https://doc.rust-lang.org/reference/expressions.html#expression-precedence).