### PR TITLE
Provide a const descriptor array

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -234,9 +234,13 @@ pub fn gen_hid_descriptor(args: TokenStream, input: TokenStream) -> TokenStream 
         #[repr(C, packed)]
         #decl
 
+        impl #ident {
+            pub const DESC: &'static [u8] = &#descriptor;
+        }
+
         impl SerializedDescriptor for #ident {
             fn desc() -> &'static[u8] {
-                &#descriptor
+                Self::DESC
             }
         }
     };

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -228,6 +228,7 @@ pub fn gen_hid_descriptor(args: TokenStream, input: TokenStream) -> TokenStream 
         Err(e) => return e.to_compile_error().into(),
     };
     let (descriptor, fields) = output;
+    let descriptor_len = descriptor.elems.len();
 
     let mut out = quote! {
         #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -235,12 +236,12 @@ pub fn gen_hid_descriptor(args: TokenStream, input: TokenStream) -> TokenStream 
         #decl
 
         impl #ident {
-            pub const DESC: &'static [u8] = &#descriptor;
+            pub const DESC: [u8; #descriptor_len] = #descriptor;
         }
 
         impl SerializedDescriptor for #ident {
             fn desc() -> &'static[u8] {
-                Self::DESC
+                &Self::DESC
             }
         }
     };


### PR DESCRIPTION
In addition to the `fn desc()`, also provide a `const DESC: [u8; x]` where `MyReport::DESC.len()` can be used in static buffer allocations.

I've named it `DESC` to be consistent with `desc()`, though `DESCRIPTOR` would be another option.

This is useful in TrouBLE where GATT characteristic wants a statically sized buffer of the exact size as the descriptor. Tested on a ESP32-C3 with TrouBLE and a mouse report like descriptor.
